### PR TITLE
Replace nbsp and tabs with regular spaces

### DIFF
--- a/03/10.php
+++ b/03/10.php
@@ -1,12 +1,12 @@
 <?php
-  $author = "Scott Adams";
+  $author = "Scott Adams";
 
-  $out = <<<'_END'
-  Normal people believe that if it ain't broke, don't fix it.
-  Engineers believe that if it ain't broke, it doesn't have enough
-  features yet.
+  $out = <<<'_END'
+  Normal people believe that if it ain't broke, don't fix it.
+  Engineers believe that if it ain't broke, it doesn't have enough
+  features yet.
 
-  - $author.
+  - $author.
 _END;
 echo $out;
 ?>

--- a/04/21.php
+++ b/04/21.php
@@ -1,17 +1,17 @@
 <?php
   if ($bank_balance < 100)
   {
-  	$money         = 1000;
-  	$bank_balance += $money;
+    $money         = 1000;
+    $bank_balance += $money;
   }
   elseif ($bank_balance > 200)
   {
-  	$savings      += 100;
-  	$bank_balance -= 100;
+    $savings      += 100;
+    $bank_balance -= 100;
   }
   else
   {
-  	$savings      += 50;
-  	$bank_balance -= 50;
+    $savings      += 50;
+    $bank_balance -= 50;
   }
 ?>

--- a/05/02.php
+++ b/05/02.php
@@ -8,5 +8,5 @@
     return $n1 . ' ' . $n2 . ' ' . $n3;
   }
 
-  echo fix_names('WILLIAM', 'henry', 'gatES');
+  echo fix_names('WILLIAM', 'henry', 'gatES');
 ?>

--- a/05/04.php
+++ b/05/04.php
@@ -3,12 +3,12 @@
   $a2 = 'henry';
   $a3 = 'gatES';
 
-  function fix_names()
-  {
-    global $a1; $a1 = ucfirst(strtolower($a1));
-    global $a2; $a2 = ucfirst(strtolower($a2));
-    global $a3; $a3 = ucfirst(strtolower($a3));
-  }
+  function fix_names()
+  {
+    global $a1; $a1 = ucfirst(strtolower($a1));
+    global $a2; $a2 = ucfirst(strtolower($a2));
+    global $a3; $a3 = ucfirst(strtolower($a3));
+  }
 
   echo $a1 . ' ' . $a2 . ' ' . $a3 . '<br>';
   fix_names();

--- a/05/12.php
+++ b/05/12.php
@@ -1,8 +1,8 @@
 <?php
-  class User
-  {
-    public $name;
-  }
+  class User
+  {
+    public $name;
+  }
 
   $object1       = new User();
   $object1->name = "Alice";

--- a/17/05.php
+++ b/17/05.php
@@ -5,7 +5,7 @@
     $data = [
       'html' => file_get_contents('http://' . $_GET['url']),
       'color' => 'blue',
-    ];
+    ];
     echo json_encode($data);
   }
 ?>

--- a/17/jsonget.php
+++ b/17/jsonget.php
@@ -5,7 +5,7 @@
     $data = [
       'html' => file_get_contents('http://' . $_GET['url']),
       'color' => 'blue',
-    ];
+    ];
     echo json_encode($data);
   }
 ?>


### PR DESCRIPTION
Replaces whitespace characters with regular spaces. PHP has problems with code which contains non-breakable spaces.